### PR TITLE
AB#37860 - TIE - Customer portal top off support

### DIFF
--- a/src/Controllers/DataUsageController.php
+++ b/src/Controllers/DataUsageController.php
@@ -66,11 +66,18 @@ class DataUsageController
      * This will throw an ApiException if the user does not have a usage based billing policy with top offs enabled.
      * @param $accountID
      * @param int $quantity
+     * @param int $accountServiceId
      * @return mixed
      * @throws \SonarSoftware\CustomerPortalFramework\Exceptions\ApiException
      */
-    public function purchaseTopOff($accountID, $quantity = 1)
+    public function purchaseTopOff($accountID, $quantity = 1, ?int $accountServiceId = null)
     {
-        return $this->httpHelper->post("accounts/" . intval($accountID) . "/top_off", ['quantity' => intval($quantity)]);
+        $params = [
+            "quantity" => intval($quantity),
+        ];
+        if (isset($accountServiceId)) {
+            $params["account_service_id"] = $accountServiceId;
+        }
+        return $this->httpHelper->post("accounts/" . intval($accountID) . "/top_off", $params);
     }
 }


### PR DESCRIPTION
This side represents the changes to the framework to allow the account service ID to be passed back through the API call. We will have another change on the Sonar code to accept this and process.

The v1 code was also verified to be sure that it would not be impacted by the addition of this field in the parameters being passed. It should not.