### PR TITLE
AB#41462 sonarpay  customer portal  adding new credit card while making payment creates multiple auth transactions

### DIFF
--- a/src/Controllers/AccountBillingController.php
+++ b/src/Controllers/AccountBillingController.php
@@ -193,9 +193,11 @@ class AccountBillingController
      */
     public function makeCreditCardPayment($accountID, CreditCard $creditCard, $amount, $saveAndMakeAuto = false, $payment_tracker_id = null)
     {
+        ray($saveAndMakeAuto);
         if ($saveAndMakeAuto === true) {
             try {
                 $cardResult = $this->createCreditCard($accountID, $creditCard, true);
+                ray($cardResult);
 
                 if (empty($cardResult) || !property_exists($cardResult, 'success') || $cardResult->success !== true) {
                     return $cardResult;
@@ -290,6 +292,7 @@ class AccountBillingController
             ]
         );
 
+        ray($result);
         return $result;
     }
 

--- a/src/Controllers/AccountBillingController.php
+++ b/src/Controllers/AccountBillingController.php
@@ -203,8 +203,8 @@ class AccountBillingController
         if ($saveAndMakeAuto === true) {
             try {
                 $cardResult = $this->createCreditCard($accountID, $creditCard, true);
-                if ($cardResult->success !== true) {
-                    return $cardResult;
+                if (!isset($cardResult->id)) {
+                    return (object)['success' => false, 'message' => 'Card creation failed'];
                 }
 
                 // Use the same payment endpoint as existing payment methods
@@ -218,7 +218,7 @@ class AccountBillingController
             } catch (Exception $e) {
                 return (object)[
                     'success' => false,
-                    'message' => (isset($cardResult) && $cardResult->success === true)
+                    'message' => (isset($cardResult->id))
                         ? "Card with autopay stored but payment failed: " . $e->getMessage()
                         : "Card with autopay storage failed: " . $e->getMessage(),
                 ];
@@ -264,8 +264,8 @@ class AccountBillingController
         if ($saveAndMakeAuto === true) {
             try {
                 $cardResult = $this->createTokenizedCreditCard($accountID, $creditCard, true);
-                if ($cardResult->success !== true) {
-                    return $cardResult;
+                if (!isset($cardResult->id)) {
+                    return (object)['success' => false, 'message' => 'Card creation failed'];
                 }
 
                 $result = $this->makePaymentUsingExistingPaymentMethod(
@@ -278,7 +278,7 @@ class AccountBillingController
             } catch (Exception $e) {
                 return (object)[
                     'success' => false,
-                    'message' => (isset($cardResult) && $cardResult->success === true)
+                    'message' => (isset($cardResult->id))
                         ? "Card with autopay stored but payment failed: " . $e->getMessage()
                         : "Card with autopay storage failed: " . $e->getMessage(),
                 ];

--- a/src/Controllers/AccountBillingController.php
+++ b/src/Controllers/AccountBillingController.php
@@ -218,7 +218,9 @@ class AccountBillingController
             } catch (Exception $e) {
                 return (object)[
                     'success' => false,
-                    'message' => isset($cardResult) ? "Card with autopay stored but payment failed with \"" . $e->getMessage() . '"' : "",
+                    'message' => isset($cardResult)
+                        ? "Card with autopay stored but payment failed: " . $e->getMessage()
+                        : "Card with autopay storage failed: " . $e->getMessage(),
                 ];
             }
         } else {
@@ -249,7 +251,8 @@ class AccountBillingController
      * @param $accountID
      * @param TokenizedCreditCard $creditCard
      * @param $amount
-     * @param bool $saveAndMakeAuto - Not used for tokenized payments
+     * @param bool $saveAndMakeAuto - If true, saves the card before charging; if false, charges one-time only
+     * @param $payment_tracker_id
      * @return mixed
      * @throws ApiException
      */
@@ -278,7 +281,9 @@ class AccountBillingController
             } catch (Exception $e) {
                 return (object)[
                     'success' => false,
-                    'message' => isset($cardResult) ? "Card with autopay stored but payment failed with \"" . $e->getMessage() . '"' : "",
+                    'message' => isset($cardResult)
+                        ? "Card with autopay stored but payment failed: " . $e->getMessage()
+                        : "Card with autopay storage failed: " . $e->getMessage(),
                 ];
             }
         } else {

--- a/src/Controllers/AccountBillingController.php
+++ b/src/Controllers/AccountBillingController.php
@@ -182,8 +182,7 @@ class AccountBillingController
      */
 
     /**
-     * Make a one time payment with a credit card and, optionally, save it as a future automatic payment method.
-     * AB#41462 Fix: When saveAndMakeAuto is true, the card is created FIRST, then payment is made with it.
+     * When saveAndMakeAuto is true, the card is created FIRST, then payment is made with it. Otherwise, card is handled as a one-time payment and not saved.
      * @param $accountID - The account ID in Sonar
      * @param CreditCard $creditCard - A CreditCard object
      * @param $amount - The amount in the currency used in Sonar as a float
@@ -234,7 +233,9 @@ class AccountBillingController
     }
 
     /**
-     * Make a payment with a tokenized card (see https://sonar.software/apidoc/index.html#api-Account_Transactions-PostAccountOneTimeTokenizedCreditCardPayment)
+     * Make a payment with a tokenized cardand, optionally, save it as
+     * a future automatic payment method. This should not be used to pay with
+     * an existing payment method.
      * @param $accountID
      * @param TokenizedCreditCard $creditCard
      * @param $amount

--- a/src/Controllers/AccountBillingController.php
+++ b/src/Controllers/AccountBillingController.php
@@ -203,6 +203,9 @@ class AccountBillingController
         if ($saveAndMakeAuto === true) {
             try {
                 $cardResult = $this->createCreditCard($accountID, $creditCard, true);
+                if ($cardResult->success !== true) {
+                    throw new Exception($cardResult->message);
+                }
 
                 // Use the same payment endpoint as existing payment methods
                 $result = $this->makePaymentUsingExistingPaymentMethod(
@@ -211,14 +214,15 @@ class AccountBillingController
                     $amount,
                     $payment_tracker_id
                 );
+                if ($result->success !== true) {
+                    throw new Exception($result->message);
+                }
 
-                $result->success = true;
-                $result->message = "Card stored with Autopay and Payment successful";
                 return $result;
             } catch (Exception $e) {
                 return (object)[
                     'success' => false,
-                    'message' => isset($cardResult)
+                    'message' => (isset($cardResult) && $cardResult->success === true)
                         ? "Card with autopay stored but payment failed: " . $e->getMessage()
                         : "Card with autopay storage failed: " . $e->getMessage(),
                 ];
@@ -267,6 +271,9 @@ class AccountBillingController
         if ($saveAndMakeAuto === true) {
             try {
                 $cardResult = $this->createTokenizedCreditCard($accountID, $creditCard, true);
+                if ($cardResult->success !== true) {
+                    throw new Exception($cardResult->message);
+                }
 
                 $result = $this->makePaymentUsingExistingPaymentMethod(
                     $accountID,
@@ -274,14 +281,15 @@ class AccountBillingController
                     $amount,
                     $payment_tracker_id
                 );
+                if ($result->success !== true) {
+                    throw new Exception($result->message);
+                }
 
-                $result->success = true;
-                $result->message = "Card stored with Autopay and Payment successful";
                 return $result;
             } catch (Exception $e) {
                 return (object)[
                     'success' => false,
-                    'message' => isset($cardResult)
+                    'message' => (isset($cardResult) && $cardResult->success === true)
                         ? "Card with autopay stored but payment failed: " . $e->getMessage()
                         : "Card with autopay storage failed: " . $e->getMessage(),
                 ];

--- a/src/Controllers/AccountBillingController.php
+++ b/src/Controllers/AccountBillingController.php
@@ -182,77 +182,26 @@ class AccountBillingController
      */
 
     /**
-     * Make a one time payment with a credit card and, optionally, save it as a future automatic payment method. This should not be used to pay with an existing payment method.
+     * Make a one time payment with a credit card and, optionally, save it as a future automatic payment method.
+     * AB#41462 Fix: When saveAndMakeAuto is true, the card is created FIRST, then payment is made with it.
      * @param $accountID - The account ID in Sonar
      * @param CreditCard $creditCard - A CreditCard object
      * @param $amount - The amount in the currency used in Sonar as a float
-     * @param bool $saveAndMakeAuto - If this is true, save the card if it successfully runs
+     * @param bool $saveAndMakeAuto - If true, save the card FIRST with autopay, then pay with it
      * @return mixed
      * @throws ApiException
      */
     public function makeCreditCardPayment($accountID, CreditCard $creditCard, $amount, $saveAndMakeAuto = false, $payment_tracker_id = null)
     {
-        $result = $this->httpHelper->post("/accounts/" . intval($accountID) . "/transactions/one_time_credit_card_payment", [
-            'number' => $creditCard->getNumber(),
-            'expiration_month' => $creditCard->getExpirationMonth(),
-            'expiration_year' => $creditCard->getExpirationYear(),
-            'amount' => trim($amount),
-            'name_on_account' => $creditCard->getName(),
-            'line1' => $creditCard->getLine1(),
-            'city' => $creditCard->getCity(),
-            'state' => $creditCard->getState(),
-            'zip' => $creditCard->getZip(),
-            'country' => $creditCard->getCountry(),
-            'cvc' => $creditCard->getCvc(),
-            'payment_tracker_id' => $payment_tracker_id,
-            'email_payment_receipt' => true,
-        ]);
-
-        if ($result->success === true && $saveAndMakeAuto === true) {
-            try {
-                $this->createCreditCard($accountID, $creditCard);
-            } catch (Exception $e) {
-                //Not much we can do here, the payment has already been run. Very unlikely payment will work and saving will fail.
-            }
-        }
-        unset($creditCard);
-
-        return $result;
-    }
-
-    /**
-     * Make a payment with a tokenized card and, optionally, save it as
-     * a future automatic payment method. This should not be used to pay with
-     * an existing payment method.
-     *
-     * AB#41462 Fix: When saveAndMakeAuto is true, the card is created FIRST with autopay,
-     * then the payment is made using that saved card. This ensures first_successful_transaction_id
-     * is preserved for proper Payrix profile linkage.
-     *
-     * @param $accountID - The account ID in Sonar
-     * @param TokenizedCreditCard $creditCard - A TokenizedCreditCard object
-     * @param $amount - The amount in the currency used in Sonar as a float
-     * @param bool $saveAndMakeAuto - If true, save the card with autopay, then pay with it
-     * @return mixed
-     * @throws ApiException
-     */
-    public function makeTokenizedCreditCardPayment(
-        $accountID,
-        TokenizedCreditCard $creditCard,
-        $amount,
-        $saveAndMakeAuto = false,
-        $payment_tracker_id = null
-    )
-    {
         if ($saveAndMakeAuto === true) {
             try {
-                $cardResult = $this->createTokenizedCreditCard($accountID, $creditCard, true);
+                $cardResult = $this->createCreditCard($accountID, $creditCard, true);
 
-                if (!isset($cardResult['success']) || $cardResult['success'] !== true) {
+                if (!isset($cardResult->success) || $cardResult->success !== true) {
                     return $cardResult;
                 }
 
-                $paymentMethodId = $cardResult['payment_methods']['entities'][0]['id'] ?? null;
+                $paymentMethodId = $cardResult->payment_methods->entities[0]->id ?? null;
 
                 if (empty($paymentMethodId)) {
                     return (object)[
@@ -276,29 +225,65 @@ class AccountBillingController
                 ];
             }
         } else {
-            $result = $this->httpHelper->post(
-                "/accounts/" . intval($accountID) . "/transactions/one_time_tokenized_credit_card_payment",
-                [
-                    'customer_profile_id' => $creditCard->getCustomerId(),
-                    'credit_card_type' => strtoupper($creditCard->getCardType()),
-                    'name_on_card' => $creditCard->getName(),
-                    'token' => $creditCard->getToken(),
-                    'expiration_month' => $creditCard->getExpirationMonth(),
-                    'expiration_year' => $creditCard->getExpirationYear(),
-                    'masked_number' => $creditCard->getIdentifier(),
-                    'line1' => $creditCard->getLine1(),
-                    'city' => $creditCard->getCity(),
-                    'state' => $creditCard->getState(),
-                    'zip' => $creditCard->getZip(),
-                    'country' => $creditCard->getCountry(),
-                    'amount' => trim($amount),
-                    'payment_tracker_id' => $payment_tracker_id,
-                    'email_payment_receipt' => true,
-                ]
-            );
+            $result = $this->httpHelper->post("/accounts/" . intval($accountID) . "/transactions/one_time_credit_card_payment", [
+                'number' => $creditCard->getNumber(),
+                'expiration_month' => $creditCard->getExpirationMonth(),
+                'expiration_year' => $creditCard->getExpirationYear(),
+                'amount' => trim($amount),
+                'name_on_account' => $creditCard->getName(),
+                'line1' => $creditCard->getLine1(),
+                'city' => $creditCard->getCity(),
+                'state' => $creditCard->getState(),
+                'zip' => $creditCard->getZip(),
+                'country' => $creditCard->getCountry(),
+                'cvc' => $creditCard->getCvc(),
+                'payment_tracker_id' => $payment_tracker_id,
+                'email_payment_receipt' => true,
+            ]);
 
             return $result;
         }
+    }
+
+    /**
+     * Make a payment with a tokenized card (see https://sonar.software/apidoc/index.html#api-Account_Transactions-PostAccountOneTimeTokenizedCreditCardPayment)
+     * @param $accountID
+     * @param TokenizedCreditCard $creditCard
+     * @param $amount
+     * @param bool $saveAndMakeAuto - Not used for tokenized payments
+     * @return mixed
+     * @throws ApiException
+     */
+    public function makeTokenizedCreditCardPayment(
+        $accountID,
+        TokenizedCreditCard $creditCard,
+        $amount,
+        $saveAndMakeAuto = false,
+        $payment_tracker_id = null
+    )
+    {
+        $result = $this->httpHelper->post(
+            "/accounts/" . intval($accountID) . "/transactions/one_time_tokenized_credit_card_payment",
+            [
+                'customer_profile_id' => $creditCard->getCustomerId(),
+                'credit_card_type' => strtoupper($creditCard->getCardType()),
+                'name_on_card' => $creditCard->getName(),
+                'token' => $creditCard->getToken(),
+                'expiration_month' => $creditCard->getExpirationMonth(),
+                'expiration_year' => $creditCard->getExpirationYear(),
+                'masked_number' => $creditCard->getIdentifier(),
+                'line1' => $creditCard->getLine1(),
+                'city' => $creditCard->getCity(),
+                'state' => $creditCard->getState(),
+                'zip' => $creditCard->getZip(),
+                'country' => $creditCard->getCountry(),
+                'amount' => trim($amount),
+                'payment_tracker_id' => $payment_tracker_id,
+                'email_payment_receipt' => true,
+            ]
+        );
+
+        return $result;
     }
 
     /**

--- a/src/Controllers/AccountBillingController.php
+++ b/src/Controllers/AccountBillingController.php
@@ -197,32 +197,32 @@ class AccountBillingController
         if ($saveAndMakeAuto === true) {
             try {
                 $cardResult = $this->createCreditCard($accountID, $creditCard, true);
-                ray($cardResult);
+                ray('Card created', $cardResult);
 
-                if (empty($cardResult) || !property_exists($cardResult, 'success') || $cardResult->success !== true) {
-                    return $cardResult;
+                if (empty($cardResult) || !property_exists($cardResult, 'payment_methods')) {
+                    return (object)[
+                        'success' => false,
+                        'message' => 'Failed to create payment method',
+                    ];
                 }
 
-                // Extract tokenized card from response
-                $paymentMethods = property_exists($cardResult, 'payment_methods') && property_exists($cardResult->payment_methods, 'entities')
-                    ? $cardResult->payment_methods->entities
-                    : [];
+                $paymentMethod = $cardResult->payment_methods;
 
-                if (empty($paymentMethods)) {
+                if (empty($paymentMethod) || !property_exists($paymentMethod, 'id')) {
                     return (object)[
                         'success' => false,
                         'message' => 'Failed to retrieve payment method after card creation',
                     ];
                 }
 
-                $tokenizedCard = $this->getTokenizedCard($paymentMethods[0]);
+                $paymentMethodId = $paymentMethod->id;
+                ray('Using payment method ID for payment', $paymentMethodId);
 
-                // Use tokenized payment method for the actual payment
-                $result = $this->makeTokenizedCreditCardPayment(
+                // Use the same payment endpoint as existing payment methods
+                $result = $this->makePaymentUsingExistingPaymentMethod(
                     $accountID,
-                    $tokenizedCard,
+                    $paymentMethodId,
                     $amount,
-                    false,
                     $payment_tracker_id
                 );
 

--- a/src/Controllers/AccountBillingController.php
+++ b/src/Controllers/AccountBillingController.php
@@ -454,33 +454,31 @@ class AccountBillingController
     {
         $paymentMethod = $paymentMethods;
 
-        // Create a TokenizedCreditCard from the saved payment method
-        $tokenizedCard = new TokenizedCreditCard(
-            $paymentMethod->token ?? null,
-            $paymentMethod->credit_card_type ?? null,
-            $paymentMethod->expiration_month ?? null,
-            $paymentMethod->expiration_year ?? null,
-            $paymentMethod->masked_number ?? null,
-            $paymentMethod->name_on_card ?? null,
-            $paymentMethod->customer_profile_id ?? null
-        );
+        ray('Portal: Payment method structure')->dump(get_object_vars($paymentMethod));
 
-        // Set address fields if available
-        if (property_exists($paymentMethod, 'line1')) {
-            $tokenizedCard->setLine1($paymentMethod->line1);
-        }
-        if (property_exists($paymentMethod, 'city')) {
-            $tokenizedCard->setCity($paymentMethod->city);
-        }
-        if (property_exists($paymentMethod, 'state')) {
-            $tokenizedCard->setState($paymentMethod->state);
-        }
-        if (property_exists($paymentMethod, 'zip')) {
-            $tokenizedCard->setZip($paymentMethod->zip);
-        }
-        if (property_exists($paymentMethod, 'country')) {
-            $tokenizedCard->setCountry($paymentMethod->country);
-        }
+        // Create a TokenizedCreditCard from the saved payment method using array constructor
+        $tokenizedCard = new TokenizedCreditCard([
+            'customer_id' => $paymentMethod->customer_profile_id ?? null,
+            'token' => $paymentMethod->token ?? null,
+            'identifier' => $paymentMethod->masked_number ?? $paymentMethod->identifier ?? null,
+            'expiration_month' => $paymentMethod->expiration_month ?? null,
+            'expiration_year' => $paymentMethod->expiration_year ?? null,
+            'line1' => $paymentMethod->line1 ?? null,
+            'city' => $paymentMethod->city ?? null,
+            'state' => $paymentMethod->state ?? null,
+            'zip' => $paymentMethod->zip ?? null,
+            'country' => $paymentMethod->country ?? null,
+            'name' => $paymentMethod->name_on_card ?? $paymentMethod->name_on_account ?? null,
+            'card_type' => $paymentMethod->credit_card_type ?? $paymentMethod->card_type ?? null,
+        ]);
+
+        ray('Portal: TokenizedCreditCard created')->dump([
+            'token' => $tokenizedCard->getToken(),
+            'cardType' => $tokenizedCard->getCardType(),
+            'customerId' => $tokenizedCard->getCustomerId(),
+            'identifier' => $tokenizedCard->getIdentifier(),
+        ]);
+
         return $tokenizedCard;
     }
 }

--- a/src/Controllers/AccountBillingController.php
+++ b/src/Controllers/AccountBillingController.php
@@ -193,13 +193,12 @@ class AccountBillingController
      */
     public function makeCreditCardPayment($accountID, CreditCard $creditCard, $amount, $saveAndMakeAuto = false, $payment_tracker_id = null)
     {
-        ray($saveAndMakeAuto);
         if ($saveAndMakeAuto === true) {
             try {
                 $cardResult = $this->createCreditCard($accountID, $creditCard, true);
                 ray('Card created', $cardResult);
 
-                if (empty($cardResult) || !property_exists($cardResult, 'payment_methods')) {
+                if (empty($cardResult)) {
                     return (object)[
                         'success' => false,
                         'message' => 'Failed to create payment method',

--- a/src/Controllers/AccountBillingController.php
+++ b/src/Controllers/AccountBillingController.php
@@ -261,28 +261,52 @@ class AccountBillingController
         $payment_tracker_id = null
     )
     {
-        $result = $this->httpHelper->post(
-            "/accounts/" . intval($accountID) . "/transactions/one_time_tokenized_credit_card_payment",
-            [
-                'customer_profile_id' => $creditCard->getCustomerId(),
-                'credit_card_type' => strtoupper($creditCard->getCardType()),
-                'name_on_card' => $creditCard->getName(),
-                'token' => $creditCard->getToken(),
-                'expiration_month' => $creditCard->getExpirationMonth(),
-                'expiration_year' => $creditCard->getExpirationYear(),
-                'masked_number' => $creditCard->getIdentifier(),
-                'line1' => $creditCard->getLine1(),
-                'city' => $creditCard->getCity(),
-                'state' => $creditCard->getState(),
-                'zip' => $creditCard->getZip(),
-                'country' => $creditCard->getCountry(),
-                'amount' => trim($amount),
-                'payment_tracker_id' => $payment_tracker_id,
-                'email_payment_receipt' => true,
-            ]
-        );
+        if ($saveAndMakeAuto === true) {
+            try {
+                $cardResult = $this->createTokenizedCreditCard($accountID, $creditCard, true);
 
-        return $result;
+                $result = $this->makePaymentUsingExistingPaymentMethod(
+                    $accountID,
+                    $cardResult->id,
+                    $amount,
+                    $payment_tracker_id
+                );
+
+                $result->success = true;
+                $result->message = "Card stored with Autopay and Payment successful";
+                return $result;
+            } catch (Exception $e) {
+                return (object)[
+                    'success' => false,
+                    'message' => isset($cardResult) ? "Card with autopay stored but payment failed with \"" . $e->getMessage() . '"' : "",
+                ];
+            }
+        } else {
+            $result = $this->httpHelper->post(
+                "/accounts/" . intval($accountID) . "/transactions/one_time_tokenized_credit_card_payment",
+                [
+                    'customer_profile_id' => $creditCard->getCustomerId(),
+                    'credit_card_type' => strtoupper($creditCard->getCardType()),
+                    'name_on_card' => $creditCard->getName(),
+                    'token' => $creditCard->getToken(),
+                    'expiration_month' => $creditCard->getExpirationMonth(),
+                    'expiration_year' => $creditCard->getExpirationYear(),
+                    'masked_number' => $creditCard->getIdentifier(),
+                    'line1' => $creditCard->getLine1(),
+                    'city' => $creditCard->getCity(),
+                    'state' => $creditCard->getState(),
+                    'zip' => $creditCard->getZip(),
+                    'country' => $creditCard->getCountry(),
+                    'amount' => trim($amount),
+                    'payment_tracker_id' => $payment_tracker_id,
+                    'email_payment_receipt' => true,
+                ]
+            );
+
+            $result->success = true;
+            $result->message = "One time payment successful";
+            return $result;
+        }
     }
 
     /**

--- a/src/Controllers/AccountBillingController.php
+++ b/src/Controllers/AccountBillingController.php
@@ -182,11 +182,13 @@ class AccountBillingController
      */
 
     /**
-     * When saveAndMakeAuto is true, the card is created FIRST, then payment is made with it. Otherwise, card is handled as a one-time payment and not saved.
-     * @param $accountID - The account ID in Sonar
-     * @param CreditCard $creditCard - A CreditCard object
-     * @param $amount - The amount in the currency used in Sonar as a float
-     * @param bool $saveAndMakeAuto - If true, save the card FIRST with autopay, then pay with it
+     * Make a one time payment with a tokenized card and, optionally, save it as
+     * * a future automatic payment method. This should not be used to pay with
+     * * an existing payment method.
+     * * @param $accountID - The account ID in Sonar
+     * * @param TokenizedCreditCard $creditCard - A TokenizedCreditCard object
+     * * @param $amount - The amount in the currency used in Sonar as a float
+     * * @param bool $saveAndMakeAuto - If this is true, save the card if it successfully runs
      * @return mixed
      * @throws ApiException
      */
@@ -206,9 +208,17 @@ class AccountBillingController
 
                 return $result;
             } catch (Exception $e) {
+                if (isset($cardResult)) {
+                    // Card save succeeded at line 199; payment failed at line 202
+                    $message = "Card saved but payment failed with " . $e->getMessage();
+                } else {
+                    // Card save failed at line 199
+                    $message = "Payment processing failed: " . $e->getMessage();
+                }
+
                 return (object)[
                     'success' => false,
-                    'message' => 'Payment processing failed: ' . $e->getMessage(),
+                    'message' => $message,
                 ];
             }
         } else {
@@ -233,9 +243,7 @@ class AccountBillingController
     }
 
     /**
-     * Make a payment with a tokenized cardand, optionally, save it as
-     * a future automatic payment method. This should not be used to pay with
-     * an existing payment method.
+     * Make a payment with a tokenized card (see https://sonar.software/apidoc/index.html#api-Account_Transactions-PostAccountOneTimeTokenizedCreditCardPayment)
      * @param $accountID
      * @param TokenizedCreditCard $creditCard
      * @param $amount

--- a/src/Controllers/AccountBillingController.php
+++ b/src/Controllers/AccountBillingController.php
@@ -198,23 +198,7 @@ class AccountBillingController
                 $cardResult = $this->createCreditCard($accountID, $creditCard, true);
                 ray('Card created', $cardResult);
 
-                if (empty($cardResult)) {
-                    return (object)[
-                        'success' => false,
-                        'message' => 'Failed to create payment method',
-                    ];
-                }
-
-                $paymentMethod = $cardResult->payment_methods;
-
-                if (empty($paymentMethod) || !property_exists($paymentMethod, 'id')) {
-                    return (object)[
-                        'success' => false,
-                        'message' => 'Failed to retrieve payment method after card creation',
-                    ];
-                }
-
-                $paymentMethodId = $paymentMethod->id;
+                $paymentMethodId = $cardResult->id;
                 ray('Using payment method ID for payment', $paymentMethodId);
 
                 // Use the same payment endpoint as existing payment methods

--- a/src/Controllers/AccountBillingController.php
+++ b/src/Controllers/AccountBillingController.php
@@ -201,19 +201,26 @@ class AccountBillingController
                     return $cardResult;
                 }
 
-                $paymentMethodId = property_exists($cardResult, 'payment_methods') && property_exists($cardResult->payment_methods, 'entities') ? $cardResult->payment_methods->entities[0]->id ?? null : null;
+                // Extract tokenized card from response
+                $paymentMethods = property_exists($cardResult, 'payment_methods') && property_exists($cardResult->payment_methods, 'entities')
+                    ? $cardResult->payment_methods->entities
+                    : [];
 
-                if (empty($paymentMethodId)) {
+                if (empty($paymentMethods)) {
                     return (object)[
                         'success' => false,
-                        'message' => 'Failed to retrieve payment method ID after card creation',
+                        'message' => 'Failed to retrieve payment method after card creation',
                     ];
                 }
 
-                $result = $this->makePaymentUsingExistingPaymentMethod(
+                $tokenizedCard = $this->getTokenizedCard($paymentMethods[0]);
+
+                // Use tokenized payment method for the actual payment
+                $result = $this->makeTokenizedCreditCardPayment(
                     $accountID,
-                    $paymentMethodId,
+                    $tokenizedCard,
                     $amount,
+                    false,
                     $payment_tracker_id
                 );
 
@@ -437,5 +444,43 @@ class AccountBillingController
     public function deletePaymentMethodByID($accountID, $paymentMethodID)
     {
         return $this->httpHelper->delete("/accounts/" . intval($accountID) . "/payment_methods/" . intval($paymentMethodID));
+    }
+
+    /**
+     * @param $paymentMethods
+     * @return TokenizedCreditCard
+     */
+    public function getTokenizedCard($paymentMethods): TokenizedCreditCard
+    {
+        $paymentMethod = $paymentMethods;
+
+        // Create a TokenizedCreditCard from the saved payment method
+        $tokenizedCard = new TokenizedCreditCard(
+            $paymentMethod->token ?? null,
+            $paymentMethod->credit_card_type ?? null,
+            $paymentMethod->expiration_month ?? null,
+            $paymentMethod->expiration_year ?? null,
+            $paymentMethod->masked_number ?? null,
+            $paymentMethod->name_on_card ?? null,
+            $paymentMethod->customer_profile_id ?? null
+        );
+
+        // Set address fields if available
+        if (property_exists($paymentMethod, 'line1')) {
+            $tokenizedCard->setLine1($paymentMethod->line1);
+        }
+        if (property_exists($paymentMethod, 'city')) {
+            $tokenizedCard->setCity($paymentMethod->city);
+        }
+        if (property_exists($paymentMethod, 'state')) {
+            $tokenizedCard->setState($paymentMethod->state);
+        }
+        if (property_exists($paymentMethod, 'zip')) {
+            $tokenizedCard->setZip($paymentMethod->zip);
+        }
+        if (property_exists($paymentMethod, 'country')) {
+            $tokenizedCard->setCountry($paymentMethod->country);
+        }
+        return $tokenizedCard;
     }
 }

--- a/src/Controllers/AccountBillingController.php
+++ b/src/Controllers/AccountBillingController.php
@@ -197,11 +197,11 @@ class AccountBillingController
             try {
                 $cardResult = $this->createCreditCard($accountID, $creditCard, true);
 
-                if (!isset($cardResult->success) || $cardResult->success !== true) {
+                if (empty($cardResult) || !property_exists($cardResult, 'success') || $cardResult->success !== true) {
                     return $cardResult;
                 }
 
-                $paymentMethodId = $cardResult->payment_methods->entities[0]->id ?? null;
+                $paymentMethodId = property_exists($cardResult, 'payment_methods') && property_exists($cardResult->payment_methods, 'entities') ? $cardResult->payment_methods->entities[0]->id ?? null : null;
 
                 if (empty($paymentMethodId)) {
                     return (object)[

--- a/src/Controllers/AccountBillingController.php
+++ b/src/Controllers/AccountBillingController.php
@@ -182,13 +182,20 @@ class AccountBillingController
      */
 
     /**
-     * Make a one time payment with a tokenized card and, optionally, save it as
-     * * a future automatic payment method. This should not be used to pay with
-     * * an existing payment method.
-     * * @param $accountID - The account ID in Sonar
-     * * @param TokenizedCreditCard $creditCard - A TokenizedCreditCard object
-     * * @param $amount - The amount in the currency used in Sonar as a float
-     * * @param bool $saveAndMakeAuto - If this is true, save the card if it successfully runs
+     * Make a one time payment with a credit card and, optionally, save it as
+     * a future automatic payment method. This should not be used to pay with
+     * an existing payment method.
+     *
+     * Note: Return type varies based on saveAndMakeAuto flag:
+     * - saveAndMakeAuto=true: Returns response from /transactions/payments endpoint
+     * - saveAndMakeAuto=false: Returns response from /transactions/one_time_credit_card_payment endpoint
+     * On failure: Returns {success: false, message: string}
+     *
+     * @param $accountID - The account ID in Sonar
+     * @param CreditCard $creditCard - A CreditCard object
+     * @param $amount - The amount in the currency used in Sonar as a float
+     * @param bool $saveAndMakeAuto - If this is true, save the card if it successfully runs
+     * @param $payment_tracker_id - Optional tracker ID for the payment transaction
      * @return mixed
      * @throws ApiException
      */

--- a/src/Controllers/AccountBillingController.php
+++ b/src/Controllers/AccountBillingController.php
@@ -204,7 +204,7 @@ class AccountBillingController
             try {
                 $cardResult = $this->createCreditCard($accountID, $creditCard, true);
                 if ($cardResult->success !== true) {
-                    throw new Exception($cardResult->message);
+                    return $cardResult;
                 }
 
                 // Use the same payment endpoint as existing payment methods
@@ -214,10 +214,6 @@ class AccountBillingController
                     $amount,
                     $payment_tracker_id
                 );
-                if ($result->success !== true) {
-                    throw new Exception($result->message);
-                }
-
                 return $result;
             } catch (Exception $e) {
                 return (object)[
@@ -243,9 +239,6 @@ class AccountBillingController
                 'payment_tracker_id' => $payment_tracker_id,
                 'email_payment_receipt' => true,
             ]);
-
-            $result->success = true;
-            $result->message = "One time payment successful";
             return $result;
         }
     }
@@ -272,7 +265,7 @@ class AccountBillingController
             try {
                 $cardResult = $this->createTokenizedCreditCard($accountID, $creditCard, true);
                 if ($cardResult->success !== true) {
-                    throw new Exception($cardResult->message);
+                    return $cardResult;
                 }
 
                 $result = $this->makePaymentUsingExistingPaymentMethod(
@@ -281,10 +274,6 @@ class AccountBillingController
                     $amount,
                     $payment_tracker_id
                 );
-                if ($result->success !== true) {
-                    throw new Exception($result->message);
-                }
-
                 return $result;
             } catch (Exception $e) {
                 return (object)[
@@ -315,9 +304,6 @@ class AccountBillingController
                     'email_payment_receipt' => true,
                 ]
             );
-
-            $result->success = true;
-            $result->message = "One time payment successful";
             return $result;
         }
     }

--- a/src/Controllers/AccountBillingController.php
+++ b/src/Controllers/AccountBillingController.php
@@ -13,6 +13,7 @@ use SonarSoftware\CustomerPortalFramework\Models\TokenizedCreditCard;
 class AccountBillingController
 {
     private $httpHelper;
+
     /**
      * AccountAuthenticationController constructor.
      */
@@ -148,9 +149,9 @@ class AccountBillingController
     /**
      * Get a list of unexpired credit cards on the account (see https://sonar.software/apidoc/index.html#api-Account_Payment_Methods-GetAccountPaymentMethods). This does not return CreditCard objects, but just the raw API return. This is because the credit card objects
      * don't really match up - we can't access the credit card number, for example. Same thing with bank accounts.
-     * @throws ApiException
      * @param $accountID
      * @return array
+     * @throws ApiException
      */
     public function getValidPaymentMethods($accountID)
     {
@@ -207,13 +208,10 @@ class AccountBillingController
             'email_payment_receipt' => true,
         ]);
 
-        if ($result->success === true && $saveAndMakeAuto === true)
-        {
+        if ($result->success === true && $saveAndMakeAuto === true) {
             try {
                 $this->createCreditCard($accountID, $creditCard);
-            }
-            catch (Exception $e)
-            {
+            } catch (Exception $e) {
                 //Not much we can do here, the payment has already been run. Very unlikely payment will work and saving will fail.
             }
         }
@@ -223,13 +221,18 @@ class AccountBillingController
     }
 
     /**
-     * Make a one time payment with a tokenized card and, optionally, save it as
+     * Make a payment with a tokenized card and, optionally, save it as
      * a future automatic payment method. This should not be used to pay with
      * an existing payment method.
+     *
+     * AB#41462 Fix: When saveAndMakeAuto is true, the card is created FIRST with autopay,
+     * then the payment is made using that saved card. This ensures first_successful_transaction_id
+     * is preserved for proper Payrix profile linkage.
+     *
      * @param $accountID - The account ID in Sonar
      * @param TokenizedCreditCard $creditCard - A TokenizedCreditCard object
      * @param $amount - The amount in the currency used in Sonar as a float
-     * @param bool $saveAndMakeAuto - If this is true, save the card if it successfully runs
+     * @param bool $saveAndMakeAuto - If true, save the card with autopay, then pay with it
      * @return mixed
      * @throws ApiException
      */
@@ -241,41 +244,63 @@ class AccountBillingController
         $payment_tracker_id = null
     )
     {
-        $result = $this->httpHelper->post(
-            "/accounts/" . intval($accountID) . "/transactions/one_time_tokenized_credit_card_payment",
-            [
-                'customer_profile_id' => $creditCard->getCustomerId(),
-                'credit_card_type' => strtoupper($creditCard->getCardType()),
-                'name_on_card' => $creditCard->getName(),
-                'token' => $creditCard->getToken(),
-                'expiration_month' => $creditCard->getExpirationMonth(),
-                'expiration_year' => $creditCard->getExpirationYear(),
-                'masked_number' => $creditCard->getIdentifier(),
-                'line1' => $creditCard->getLine1(),
-                'city' => $creditCard->getCity(),
-                'state' => $creditCard->getState(),
-                'zip' => $creditCard->getZip(),
-                'country' => $creditCard->getCountry(),
-                'amount' => trim($amount),
-                'payment_tracker_id' => $payment_tracker_id,
-                'email_payment_receipt' => true,
-            ]
-        );
-
-        if ($result->success === true && $saveAndMakeAuto === true)
-        {
+        if ($saveAndMakeAuto === true) {
             try {
-                $this->createTokenizedCreditCard($accountID, $creditCard);
-            }
-            catch (Exception $e)
-            {
-                // Not much we can do here, the payment has already been run.
-                // Very unlikely payment will work and saving will fail.
-            }
-        }
+                $cardResult = $this->createTokenizedCreditCard($accountID, $creditCard, true);
 
-        return $result;
+                if (!isset($cardResult['success']) || $cardResult['success'] !== true) {
+                    return $cardResult;
+                }
+
+                $paymentMethodId = $cardResult['payment_methods']['entities'][0]['id'] ?? null;
+
+                if (empty($paymentMethodId)) {
+                    return (object)[
+                        'success' => false,
+                        'message' => 'Failed to retrieve payment method ID after card creation',
+                    ];
+                }
+
+                $result = $this->makePaymentUsingExistingPaymentMethod(
+                    $accountID,
+                    $paymentMethodId,
+                    $amount,
+                    $payment_tracker_id
+                );
+
+                return $result;
+            } catch (Exception $e) {
+                return (object)[
+                    'success' => false,
+                    'message' => 'Payment processing failed: ' . $e->getMessage(),
+                ];
+            }
+        } else {
+            $result = $this->httpHelper->post(
+                "/accounts/" . intval($accountID) . "/transactions/one_time_tokenized_credit_card_payment",
+                [
+                    'customer_profile_id' => $creditCard->getCustomerId(),
+                    'credit_card_type' => strtoupper($creditCard->getCardType()),
+                    'name_on_card' => $creditCard->getName(),
+                    'token' => $creditCard->getToken(),
+                    'expiration_month' => $creditCard->getExpirationMonth(),
+                    'expiration_year' => $creditCard->getExpirationYear(),
+                    'masked_number' => $creditCard->getIdentifier(),
+                    'line1' => $creditCard->getLine1(),
+                    'city' => $creditCard->getCity(),
+                    'state' => $creditCard->getState(),
+                    'zip' => $creditCard->getZip(),
+                    'country' => $creditCard->getCountry(),
+                    'amount' => trim($amount),
+                    'payment_tracker_id' => $payment_tracker_id,
+                    'email_payment_receipt' => true,
+                ]
+            );
+
+            return $result;
+        }
     }
+
     /**
      * Make a payment using an existing payment method ID (see https://sonar.software/apidoc/index.html#api-Account_Transactions-PostAccountPayment)
      * @param $accountID
@@ -388,7 +413,7 @@ class AccountBillingController
     public function storePayPalPayment($accountID, $amount, $transactionID)
     {
         return $this->httpHelper->post("/accounts/" . intval($accountID) . "/transactions/paypal_payments", [
-            'amount' => number_format($amount,2,".",""),
+            'amount' => number_format($amount, 2, ".", ""),
             'transaction_id' => trim($transactionID),
             'email_payment_receipt' => true,
         ]);

--- a/src/Controllers/AccountBillingController.php
+++ b/src/Controllers/AccountBillingController.php
@@ -325,6 +325,7 @@ class AccountBillingController
      */
     public function createCreditCard($accountID, CreditCard $creditCard, $auto = true)
     {
+        ray($creditCard);
         return $this->httpHelper->post("/accounts/" . intval($accountID) . "/payment_methods", [
             'type' => 'credit card',
             'account_number' => $creditCard->getNumber(),

--- a/src/Controllers/AccountBillingController.php
+++ b/src/Controllers/AccountBillingController.php
@@ -197,7 +197,6 @@ class AccountBillingController
      * @param bool $saveAndMakeAuto - If this is true, save the card if it successfully runs
      * @param $payment_tracker_id - Optional tracker ID for the payment transaction
      * @return mixed
-     * @throws ApiException
      */
     public function makeCreditCardPayment($accountID, CreditCard $creditCard, $amount, $saveAndMakeAuto = false, $payment_tracker_id = null)
     {
@@ -213,19 +212,13 @@ class AccountBillingController
                     $payment_tracker_id
                 );
 
+                $result->success = true;
+                $result->message = "Card stored with Autopay and Payment successful";
                 return $result;
             } catch (Exception $e) {
-                if (isset($cardResult)) {
-                    // Card save succeeded at line 199; payment failed at line 202
-                    $message = "Card saved but payment failed with " . $e->getMessage();
-                } else {
-                    // Card save failed at line 199
-                    $message = "Payment processing failed: " . $e->getMessage();
-                }
-
                 return (object)[
                     'success' => false,
-                    'message' => $message,
+                    'message' => isset($cardResult) ? "Card with autopay stored but payment failed with \"" . $e->getMessage() . '"' : "",
                 ];
             }
         } else {
@@ -245,6 +238,8 @@ class AccountBillingController
                 'email_payment_receipt' => true,
             ]);
 
+            $result->success = true;
+            $result->message = "One time payment successful";
             return $result;
         }
     }

--- a/src/Controllers/AccountBillingController.php
+++ b/src/Controllers/AccountBillingController.php
@@ -196,15 +196,11 @@ class AccountBillingController
         if ($saveAndMakeAuto === true) {
             try {
                 $cardResult = $this->createCreditCard($accountID, $creditCard, true);
-                ray('Card created', $cardResult);
-
-                $paymentMethodId = $cardResult->id;
-                ray('Using payment method ID for payment', $paymentMethodId);
 
                 // Use the same payment endpoint as existing payment methods
                 $result = $this->makePaymentUsingExistingPaymentMethod(
                     $accountID,
-                    $paymentMethodId,
+                    $cardResult->id,
                     $amount,
                     $payment_tracker_id
                 );
@@ -275,7 +271,6 @@ class AccountBillingController
             ]
         );
 
-        ray($result);
         return $result;
     }
 
@@ -308,7 +303,6 @@ class AccountBillingController
      */
     public function createCreditCard($accountID, CreditCard $creditCard, $auto = true)
     {
-        ray($creditCard);
         return $this->httpHelper->post("/accounts/" . intval($accountID) . "/payment_methods", [
             'type' => 'credit card',
             'account_number' => $creditCard->getNumber(),
@@ -431,41 +425,5 @@ class AccountBillingController
     public function deletePaymentMethodByID($accountID, $paymentMethodID)
     {
         return $this->httpHelper->delete("/accounts/" . intval($accountID) . "/payment_methods/" . intval($paymentMethodID));
-    }
-
-    /**
-     * @param $paymentMethods
-     * @return TokenizedCreditCard
-     */
-    public function getTokenizedCard($paymentMethods): TokenizedCreditCard
-    {
-        $paymentMethod = $paymentMethods;
-
-        ray('Portal: Payment method structure')->dump(get_object_vars($paymentMethod));
-
-        // Create a TokenizedCreditCard from the saved payment method using array constructor
-        $tokenizedCard = new TokenizedCreditCard([
-            'customer_id' => $paymentMethod->customer_profile_id ?? null,
-            'token' => $paymentMethod->token ?? null,
-            'identifier' => $paymentMethod->masked_number ?? $paymentMethod->identifier ?? null,
-            'expiration_month' => $paymentMethod->expiration_month ?? null,
-            'expiration_year' => $paymentMethod->expiration_year ?? null,
-            'line1' => $paymentMethod->line1 ?? null,
-            'city' => $paymentMethod->city ?? null,
-            'state' => $paymentMethod->state ?? null,
-            'zip' => $paymentMethod->zip ?? null,
-            'country' => $paymentMethod->country ?? null,
-            'name' => $paymentMethod->name_on_card ?? $paymentMethod->name_on_account ?? null,
-            'card_type' => $paymentMethod->credit_card_type ?? $paymentMethod->card_type ?? null,
-        ]);
-
-        ray('Portal: TokenizedCreditCard created')->dump([
-            'token' => $tokenizedCard->getToken(),
-            'cardType' => $tokenizedCard->getCardType(),
-            'customerId' => $tokenizedCard->getCustomerId(),
-            'identifier' => $tokenizedCard->getIdentifier(),
-        ]);
-
-        return $tokenizedCard;
     }
 }


### PR DESCRIPTION
Prevent Payrix from creating multiple customer profiles during autopay card creation

Problem: When users created new credit cards with autopay enabled, Payrix created duplicate profiles because first_successful_transaction_id (from the $0 authorization) was lost during the card creation-then-payment flow.

  Solution: Simplified the payment flow to:
  1. Create card FIRST with auto=true (preserves first_successful_transaction_id)
  2. Extract card ID from response
  3. Use the same payment endpoint as existing cards (accepts payment_method_id)
  
  Further details:
  https://www.notion.so/34acb50d431d8117962ada74e7729283